### PR TITLE
Setup generator

### DIFF
--- a/project/modules.py
+++ b/project/modules.py
@@ -37,7 +37,8 @@ class Encoder(nn.Module):
 
     def forward(self, x):
         x = self.net(x)
-        x = x.view(hparams.batch_size, -1)
+        batch_size = x.shape[0]
+        x = x.view(batch_size, -1)
         return x
 
 

--- a/project/train.py
+++ b/project/train.py
@@ -149,9 +149,8 @@ def main(hparams):
     model = Net(hparams)
 
     # print detailed summary with estimated network size
-    # summary(model,input_size=[(hparams.batch_size, hparams.nc, hparams.img_size, hparams.img_size), 
-    #                           (hparams.batch_size, hparams.nc, hparams.img_size, hparams.img_size)],
-    #               device="cpu")
+    summary(model, input_size=[(hparams.nc, hparams.img_size, hparams.img_size), 
+                               (hparams.nc, hparams.img_size, hparams.img_size)], device="cpu")
     
     trainer = Trainer(logger=logger, gpus=hparams.gpus, max_epochs=hparams.max_epochs)
     trainer.fit(model)


### PR DESCRIPTION
- I removed the second encoder class because the architecture was exactly the same
- I reformatted the encoder a little bit to remove hardcoded values
- Introduced the Generator from the [LORD paper](https://github.com/avivga/lord-pytorch/blob/1b25569bc6ab64cdaccd07f36dc2f8b6bc170e30/model/modules.py) 
- This still remains to be tested, but as of now we are getting the expected errors because the training step is not implemented yet